### PR TITLE
@broskoski: Update with JoiQL fix and default lock_fields value

### DIFF
--- a/apps/admin/controllers/index.js
+++ b/apps/admin/controllers/index.js
@@ -15,7 +15,7 @@ const api = new Lokka({
 export const state = tree({
   events: [],
   newEvent: {},
-  event: {},
+  event: { lock_fields: false },
   reservations: []
 })
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "envify": "^3.4.0",
     "graphql": "^0.7.2",
     "hotglue": "0.0.7",
-    "joiql-mongo": "^1.0.9",
+    "joiql-mongo": "^1.0.10",
     "json2csv": "^3.7.1",
     "koa": "^2.0.0-alpha.4",
     "koa-basic-auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dotenv": "^2.0.0",
     "envify": "^3.4.0",
     "graphql": "^0.7.2",
-    "hotglue": "0.0.7",
+    "hotglue": "0.0.9",
     "joiql-mongo": "^1.0.10",
     "json2csv": "^3.7.1",
     "koa": "^2.0.0-alpha.4",


### PR DESCRIPTION
Fixes that weird bug, see https://github.com/muraljs/joiql/pull/7 and I noticed creating a new event would complain b/c it was sending down `undefined` for lock_fields in a GraphQL query. I gave it a default value of false instead.