### PR TITLE
Add event description

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem 'haml-rails'
 
 gem 'friendly_id', '~> 5.1.0'
 
+
+gem 'redcarpet'
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,7 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    redcarpet (3.3.4)
     ruby_parser (3.8.3)
       sexp_processor (~> 4.1)
     sass (3.4.22)
@@ -203,6 +204,7 @@ DEPENDENCIES
   pg
   puma (~> 3.0)
   rails (~> 5.0.0)
+  redcarpet
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
@@ -213,4 +215,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -14,6 +14,11 @@
     @include clearfix();
     padding-bottom: 20px;
   }
+
+  .help a {
+    font-size: 11px;
+    color: $gray-dark;
+  }
 }
 
 .waitlisted {

--- a/app/assets/stylesheets/rsvps.scss
+++ b/app/assets/stylesheets/rsvps.scss
@@ -50,4 +50,8 @@
       margin: 5px 0;
     }
   }
+
+  .center {
+    text-align: center;
+  }
 }

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -76,7 +76,7 @@ class Admin::EventsController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def event_params
       params.require(:event).permit(
-        :name, :presented_by, :guests_allowed, :capacity, :lock_fields, :closes_at, :fine_print
+        :name, :presented_by, :guests_allowed, :capacity, :lock_fields, :closes_at, :fine_print, :description
       )
     end
 

--- a/app/helpers/rsvps_helper.rb
+++ b/app/helpers/rsvps_helper.rb
@@ -1,2 +1,7 @@
 module RsvpsHelper
+  def markdown(text)
+    renderer = Redcarpet::Render::HTML.new(filter_html: true, no_images: true, no_styles: true, hard_wrap: true)
+    markdown = Redcarpet::Markdown.new(renderer)
+    markdown.render(text).html_safe
+  end
 end

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -23,7 +23,7 @@
   </div>
 
   <div class="field">
-    <%= f.label :description %>
+    <%= f.label :description %> <span class="help"><a href="https://daringfireball.net/projects/markdown/syntax" target="_blank">Markdown formatted</a></span>
     <%= f.text_area :description, rows: 3, class: 'form-control' %>
   </div>
 

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -23,6 +23,11 @@
   </div>
 
   <div class="field">
+    <%= f.label :description %>
+    <%= f.text_area :description, rows: 3, class: 'form-control' %>
+  </div>
+
+  <div class="field">
     <%= f.label 'How many guests are users allowed to bring?' %>
     <%= f.number_field :guests_allowed, class: 'form-control', placeholder: 'Enter 0 to hide the guest field', required: true %>
   </div>

--- a/app/views/rsvps/_footer.html.erb
+++ b/app/views/rsvps/_footer.html.erb
@@ -1,5 +1,5 @@
 <div class="rsvp__footer">
-  <div class="rsvp__footer__fine-print">
+  <div class="rsvp__footer__fine-print center">
     <%= @event.fine_print %>
   </div>
 </div>

--- a/app/views/rsvps/_header.html.erb
+++ b/app/views/rsvps/_header.html.erb
@@ -4,7 +4,7 @@
   </div>
   <h5><%= @event.presented_by %></h5>
   <h1><%= @event.name %></h1>
-  <% unless @event.description.blank? %>
+  <% if @event.description.present? %>
     <div class="center">
       <%= markdown @event.description %>
     </div>

--- a/app/views/rsvps/_header.html.erb
+++ b/app/views/rsvps/_header.html.erb
@@ -5,7 +5,7 @@
   <h5><%= @event.presented_by %></h5>
   <h1><%= @event.name %></h1>
   <% unless @event.description.blank? %>
-    <div>
+    <div class="center">
       <%= markdown @event.description %>
     </div>
   <% end %>

--- a/app/views/rsvps/_header.html.erb
+++ b/app/views/rsvps/_header.html.erb
@@ -4,4 +4,9 @@
   </div>
   <h5><%= @event.presented_by %></h5>
   <h1><%= @event.name %></h1>
+  <% unless @event.description.blank? %>
+    <div>
+      <%= markdown @event.description %>
+    </div>
+  <% end %>
 </div>

--- a/db/migrate/20161202193347_add_description_to_events.rb
+++ b/db/migrate/20161202193347_add_description_to_events.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToEvents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :events, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161129154759) do
+ActiveRecord::Schema.define(version: 20161202193347) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20161129154759) do
     t.string   "slug"
     t.datetime "closes_at"
     t.string   "fine_print"
+    t.text     "description"
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|


### PR DESCRIPTION
Closes https://github.com/artsy/collector-experience/issues/45

This adds a description field that accepts markdown markup _and_ will preserve line-breaks. I’ve opted to strip any other HTML, not allow images nor CSS, so that it will always have the look we prefer.

It also centers the text of both the description and the pre-existing fine-print.

<img width="419" alt="screen shot 2016-12-02 at 15 08 34" src="https://cloud.githubusercontent.com/assets/2320/20848790/a5c844f6-b8a1-11e6-81b6-880bc05e00f2.png">
