### PR TITLE
@alloy => Propagate a host of other http exceptions

### DIFF
--- a/lib/constellation.rb
+++ b/lib/constellation.rb
@@ -3,6 +3,27 @@ end
 
 require 'net/http'
 module Constellation
+  HTTP_ERRORS = [
+    Errno::ETIMEDOUT,
+    Timeout::Error,
+    Net::OpenTimeout,
+    Net::ReadTimeout,
+    EOFError,
+    Errno::ECONNABORTED,
+    Errno::ECONNREFUSED,
+    Errno::ECONNRESET,
+    Errno::EHOSTDOWN,
+    Errno::EHOSTUNREACH,
+    Errno::EINVAL,
+    Errno::ENETUNREACH,
+    SocketError,
+    OpenSSL::SSL::SSLError,
+    Net::HTTPBadResponse,
+    Net::HTTPHeaderSyntaxError,
+    Net::ProtocolError,
+    Zlib::GzipFile::Error,
+  ]
+
   def self.create_rsvp!(rsvp_params)
     return unless constellation_enabled?
     uri = URI.parse("#{app}/rsvps")
@@ -13,6 +34,8 @@ module Constellation
     response = http.request(req)
     raise ConstellationHttpException, response.body unless response.code == '201'
     JSON.parse(response.body)
+  rescue *HTTP_ERRORS => e
+    raise ConstellationHttpException, e.message
   end
 
   def self.constellation_enabled?

--- a/spec/lib/constellation_spec.rb
+++ b/spec/lib/constellation_spec.rb
@@ -22,5 +22,13 @@ describe 'Constellation module' do
         expect(e.message).to eq 'uh oh'
       end
     end
+    it 'raises an exception on a more generic http error' do
+      allow(Net::HTTP).to receive(:new).and_raise(SocketError.new('uh oh'))
+      expect do
+        Constellation.create_rsvp!(rsvp_params)
+      end.to raise_error(ConstellationHttpException) do |e|
+        expect(e.message).to eq 'uh oh'
+      end
+    end
   end
 end


### PR DESCRIPTION
We raise our custom-handled exception + message by rescuing from the more comprehensive error list.