### PR TITLE
@joeyAghion => Fully drop the rsvps table and model for deprecation #migration

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,8 +1,4 @@
 module EventsHelper
-  def count_to_capacity(event)
-    "#{event.rsvp_count} / #{event.capacity}"
-  end
-
   def formatted_date(date)
     return 'N/A' if date.nil?
     date.strftime("%m/%d/%Y – %I:%M%p")

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,15 +1,6 @@
 class Event < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: [:slugged, :finders]
-  has_many :rsvps
 
   validates :description, length: { maximum: 2000 }
-
-  def rsvp_count
-    rsvps.count + rsvps.inject(0) { |n, rsvp| rsvp.guests.length + n }
-  end
-
-  def is_over_capacity
-    rsvp_count > capacity
-  end
 end

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -1,26 +1,16 @@
-require 'csv'
+class Rsvp
+  include ActiveModel::Validations
+  include ActiveModel::Conversion
+  extend ActiveModel::Naming
+  attr_accessor :no_of_guests, :name, :email
 
-class Rsvp < ApplicationRecord
-  attr_accessor :no_of_guests
-  belongs_to :event
-
-  validates :name, presence: { message: "must be present" }
-  validates :email,
-    presence: { message: "must be present" },
-    format: {
-      with: /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/,
-      message: "address must be valid"
-    },
-    uniqueness: { scope: :event, message: "has already RSVPed"}
-  validate :guests_cannot_be_blank
-
-  before_validation :strip_email
-
-  def strip_email
-    email.strip!
+  def initialize(options = {})
+    @name = options[:name]
+    @email = options[:email]
+    @no_of_guests = options[:no_of_guests]
   end
 
-  def guests_cannot_be_blank
-    errors.add :guests, "can't be blank" if guests.select(&:blank?).size > 0
+  def persisted?
+    false
   end
 end

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -4,7 +4,6 @@
   <thead>
     <tr>
       <th>Name</th>
-      <th>RSVP Count</th>
       <th>Closing date</th>
       <th></th>
     </tr>
@@ -14,7 +13,6 @@
     <% @events.each do |event| %>
       <tr>
         <td><%= link_to event.name, edit_admin_event_url(event) %> - <%= link_to 'Go to form', new_rsvp_url(event), class: 'admin-events-go-to-form' %></td>
-        <td><%= count_to_capacity(event) %></td>
         <td><%= formatted_date(event.closes_at) %></td>
         <td><%= link_to 'Delete', admin_event_url(event), method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/rsvps/thank_you.html.erb
+++ b/app/views/rsvps/thank_you.html.erb
@@ -1,10 +1,6 @@
 <div class="rsvp">
   <%= render 'header' %>
-  <%- if @event.is_over_capacity %>
-    <p>Thank you for your interest in <%= @event.name %>. This event is currently at capacity, but we have added your name to our waiting list and will be in touch in the chance a space opens up. We appreciate your understanding.</p>
-  <%- else %>
-    <p>Thank you for your RSVP.</p>
-  <%- end %>
+  <p>Thank you for your RSVP.</p>
   <p>Sign up for an <a href="https://www.artsy.net">Artsy</a> account to discover and buy the world's greatest art online.</p>
   <div class="actions">
     <a href="https://www.artsy.net/sign_up" class="btn btn-primary btn-full-width">Sign Up</a>

--- a/db/migrate/20170608160905_remove_rsvps_table.rb
+++ b/db/migrate/20170608160905_remove_rsvps_table.rb
@@ -1,0 +1,5 @@
+class RemoveRsvpsTable < ActiveRecord::Migration[5.0]
+  def change
+    drop_table :rsvps
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161202193347) do
+ActiveRecord::Schema.define(version: 20170608160905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 20161202193347) do
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.string   "slug"
-    t.datetime "closes_at"
+    t.datetime "closes_at",      null: false
     t.string   "fine_print"
     t.text     "description"
   end
@@ -41,15 +41,4 @@ ActiveRecord::Schema.define(version: 20161202193347) do
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type", using: :btree
   end
 
-  create_table "rsvps", force: :cascade do |t|
-    t.string   "name"
-    t.string   "email"
-    t.string   "guests",     default: [],              array: true
-    t.integer  "event_id"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.index ["event_id"], name: "index_rsvps_on_event_id", using: :btree
-  end
-
-  add_foreign_key "rsvps", "events"
 end


### PR DESCRIPTION
Migration is to back up the database: already done.