### PR TITLE
Replace GraphQL client with Graphlient.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'redcarpet'
 
 gem 'newrelic_rpm'
 
-gem 'graphql-client'
+gem 'graphlient'
 
 group :development, :test do
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
@@ -76,11 +76,19 @@ GEM
       railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     execjs (2.7.0)
+    faraday (0.13.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
     ffi (1.9.14)
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
+    graphlient (0.0.7)
+      faraday
+      faraday_middleware
+      graphql-client
     graphql (1.7.4)
     graphql-client (0.12.1)
       activesupport (>= 3.0, < 6.0)
@@ -99,7 +107,8 @@ GEM
       haml (~> 4.0.0)
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
-    i18n (0.7.0)
+    i18n (0.9.0)
+      concurrent-ruby (~> 1.0)
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -119,8 +128,9 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.9.1)
+    minitest (5.10.3)
     multi_json (1.12.1)
+    multipart-post (2.0.0)
     neat (1.7.2)
       bourbon (>= 4.0)
       sass (>= 3.3)
@@ -203,12 +213,12 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     thor (0.19.1)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     tilt (2.0.5)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.0.3)
       execjs (>= 0.3.0, < 3)
@@ -236,7 +246,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   dotenv-rails
   friendly_id (~> 5.1.0)
-  graphql-client
+  graphlient
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails
@@ -263,4 +273,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.15.3

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -13,7 +13,7 @@ class RsvpsController < ApplicationController
     respond_to do |format|
       format.html { redirect_to thank_rsvp_url(@event, total_count: total_count) }
     end
-  rescue Constellation::GraphQLException, Constellation::HttpException => e
+  rescue StandardError => e
     logger.warn(e.message)
     respond_to do |format|
       # Add some locals that simple form expects (+ errors)

--- a/lib/constellation.rb
+++ b/lib/constellation.rb
@@ -2,13 +2,15 @@ module Constellation
 
   class GraphQLException < StandardError; end;
 
-  def self.create_rsvp!(rsvp_params)
-    client = Graphlient::Client.new(
+  def self.client
+    Graphlient::Client.new(
       "#{RsvpRails.config[:constellation_url]}/api/graphql/",
       headers: {
         'Authorization' => "Bearer #{RsvpRails.config[:constellation_jwt_token]}"
     })
+  end
 
+  def self.create_rsvp!(rsvp_params)
     mutation = <<-GRAPHQL
       mutation($input: createRsvpInput!) {
         createRsvp(input: $input) {

--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -2,16 +2,14 @@ namespace :graphql do
   directory "data"
 
   task :dump_schema => [:environment, "data"] do
-    require "graphql/client"
-    require "graphql/client/http"
-    HTTP = GraphQL::Client::HTTP.new("#{RsvpRails.config[:constellation_url]}/api/graphql/") do
-      def headers(_)
-        { 'Authorization' => "Bearer #{RsvpRails.config[:constellation_jwt_token]}" }
-      end
-    end
-    Schema = GraphQL::Client.load_schema(HTTP)
-    File.open("data/schema.graphql", "w") do |f|
-      f.write(Schema.to_definition)
+    client = Graphlient::Client.new(
+      "#{RsvpRails.config[:constellation_url]}/api/graphql/", 
+      headers: { 
+        'Authorization' => "Bearer #{RsvpRails.config[:constellation_jwt_token]}" 
+    })
+    File.open('data/schema.graphql', "w") do |f|
+      f.write(client.schema.to_definition)
+      puts "Written #{f.size} byte(s) to #{f.path}."
     end
   end
 end

--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -1,14 +1,10 @@
 namespace :graphql do
   directory "data"
 
+  desc "Dump Constellation schema for Visual Studio Code integration."
   task :dump_schema => [:environment, "data"] do
-    client = Graphlient::Client.new(
-      "#{RsvpRails.config[:constellation_url]}/api/graphql/", 
-      headers: { 
-        'Authorization' => "Bearer #{RsvpRails.config[:constellation_jwt_token]}" 
-    })
     File.open('data/schema.graphql', "w") do |f|
-      f.write(client.schema.to_definition)
+      f.write(Constellation.client.schema.to_definition)
       puts "Written #{f.size} byte(s) to #{f.path}."
     end
   end

--- a/spec/fixtures/constellation/unsuccessful_Constellation_creation.yml
+++ b/spec/fixtures/constellation/unsuccessful_Constellation_creation.yml
@@ -5,6 +5,167 @@ http_interactions:
     uri: https://constellation-staging.artsy.net/api/graphql/
     body:
       encoding: UTF-8
+      string: '{"query":"query IntrospectionQuery {\n  __schema {\n    queryType {\n      name\n    }\n    mutationType
+        {\n      name\n    }\n    subscriptionType {\n      name\n    }\n    types
+        {\n      ...FullType\n    }\n    directives {\n      name\n      description\n      locations\n      args
+        {\n        ...InputValue\n      }\n    }\n  }\n}\n\nfragment FullType on __Type
+        {\n  kind\n  name\n  description\n  fields(includeDeprecated: true) {\n    name\n    description\n    args
+        {\n      ...InputValue\n    }\n    type {\n      ...TypeRef\n    }\n    isDeprecated\n    deprecationReason\n  }\n  inputFields
+        {\n    ...InputValue\n  }\n  interfaces {\n    ...TypeRef\n  }\n  enumValues(includeDeprecated:
+        true) {\n    name\n    description\n    isDeprecated\n    deprecationReason\n  }\n  possibleTypes
+        {\n    ...TypeRef\n  }\n}\n\nfragment InputValue on __InputValue {\n  name\n  description\n  type
+        {\n    ...TypeRef\n  }\n  defaultValue\n}\n\nfragment TypeRef on __Type {\n  kind\n  name\n  ofType
+        {\n    kind\n    name\n    ofType {\n      kind\n      name\n      ofType
+        {\n        kind\n        name\n        ofType {\n          kind\n          name\n          ofType
+        {\n            kind\n            name\n            ofType {\n              kind\n              name\n              ofType
+        {\n                kind\n                name\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}","operationName":"IntrospectionQuery"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJjYXRzIn0.b1QuYVsSaM6uAQ8427p0lwCciJlWd55pe-q3lm0aCpA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 18 Oct 2017 21:03:00 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"b9fd39712aa1d42b106fccfc48a48a3d"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ced26e55-9bd8-470f-a650-0ac2b43c077f
+      X-Runtime:
+      - '0.118797'
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"__schema":{"queryType":{"name":"Query"},"mutationType":{"name":"Mutation"},"subscriptionType":null,"types":[{"kind":"SCALAR","name":"Boolean","description":"Represents
+        `true` or `false` values.","fields":null,"inputFields":null,"interfaces":null,"enumValues":null,"possibleTypes":null},{"kind":"SCALAR","name":"String","description":"Represents
+        textual data as UTF-8 character sequences. This type is most often used by
+        GraphQL to represent free-form human-readable text.","fields":null,"inputFields":null,"interfaces":null,"enumValues":null,"possibleTypes":null},{"kind":"OBJECT","name":"__Type","description":"The
+        fundamental unit of any GraphQL Schema is the type. There are many kinds of
+        types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on
+        the kind of a type, certain fields describe information about that type. Scalar
+        types provide no information beyond a name and description, while Enum types
+        provide their values. Object and Interface types provide the fields they describe.
+        Abstract types, Union and Interface, provide the Object types possible at
+        runtime. List and NonNull types compose other types.","fields":[{"name":"description","description":null,"args":[],"type":{"kind":"SCALAR","name":"String","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"enumValues","description":null,"args":[{"name":"includeDeprecated","description":null,"type":{"kind":"SCALAR","name":"Boolean","ofType":null},"defaultValue":"false"}],"type":{"kind":"LIST","name":null,"ofType":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"__EnumValue","ofType":null}}},"isDeprecated":false,"deprecationReason":null},{"name":"fields","description":null,"args":[{"name":"includeDeprecated","description":null,"type":{"kind":"SCALAR","name":"Boolean","ofType":null},"defaultValue":"false"}],"type":{"kind":"LIST","name":null,"ofType":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"__Field","ofType":null}}},"isDeprecated":false,"deprecationReason":null},{"name":"inputFields","description":null,"args":[],"type":{"kind":"LIST","name":null,"ofType":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"__InputValue","ofType":null}}},"isDeprecated":false,"deprecationReason":null},{"name":"interfaces","description":null,"args":[],"type":{"kind":"LIST","name":null,"ofType":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"__Type","ofType":null}}},"isDeprecated":false,"deprecationReason":null},{"name":"kind","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"ENUM","name":"__TypeKind","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"name","description":null,"args":[],"type":{"kind":"SCALAR","name":"String","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"ofType","description":null,"args":[],"type":{"kind":"OBJECT","name":"__Type","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"possibleTypes","description":null,"args":[],"type":{"kind":"LIST","name":null,"ofType":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"__Type","ofType":null}}},"isDeprecated":false,"deprecationReason":null}],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"ENUM","name":"__TypeKind","description":"An
+        enum describing what kind of type a given `__Type` is.","fields":null,"inputFields":null,"interfaces":null,"enumValues":[{"name":"SCALAR","description":"Indicates
+        this type is a scalar.","isDeprecated":false,"deprecationReason":null},{"name":"OBJECT","description":"Indicates
+        this type is an object. `fields` and `interfaces` are valid fields.","isDeprecated":false,"deprecationReason":null},{"name":"INTERFACE","description":"Indicates
+        this type is an interface. `fields` and `possibleTypes` are valid fields.","isDeprecated":false,"deprecationReason":null},{"name":"UNION","description":"Indicates
+        this type is a union. `possibleTypes` is a valid field.","isDeprecated":false,"deprecationReason":null},{"name":"ENUM","description":"Indicates
+        this type is an enum. `enumValues` is a valid field.","isDeprecated":false,"deprecationReason":null},{"name":"INPUT_OBJECT","description":"Indicates
+        this type is an input object. `inputFields` is a valid field.","isDeprecated":false,"deprecationReason":null},{"name":"LIST","description":"Indicates
+        this type is a list. `ofType` is a valid field.","isDeprecated":false,"deprecationReason":null},{"name":"NON_NULL","description":"Indicates
+        this type is a non-null. `ofType` is a valid field.","isDeprecated":false,"deprecationReason":null}],"possibleTypes":null},{"kind":"OBJECT","name":"__Field","description":"Object
+        and Interface types are described by a list of Fields, each of which has a
+        name, potentially a list of arguments, and a return type.","fields":[{"name":"args","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"LIST","name":null,"ofType":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"__InputValue","ofType":null}}}},"isDeprecated":false,"deprecationReason":null},{"name":"deprecationReason","description":null,"args":[],"type":{"kind":"SCALAR","name":"String","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"description","description":null,"args":[],"type":{"kind":"SCALAR","name":"String","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"isDeprecated","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"Boolean","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"name","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"type","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"__Type","ofType":null}},"isDeprecated":false,"deprecationReason":null}],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"OBJECT","name":"__InputValue","description":"Arguments
+        provided to Fields or Directives and the input fields of an InputObject are
+        represented as Input Values which describe their type and optionally a default
+        value.","fields":[{"name":"defaultValue","description":"A GraphQL-formatted
+        string representing the default value for this input value.","args":[],"type":{"kind":"SCALAR","name":"String","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"description","description":null,"args":[],"type":{"kind":"SCALAR","name":"String","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"name","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"type","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"__Type","ofType":null}},"isDeprecated":false,"deprecationReason":null}],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"OBJECT","name":"__EnumValue","description":"One
+        possible value for a given Enum. Enum values are unique values, not a placeholder
+        for a string or numeric value. However an Enum value is returned in a JSON
+        response as a string.","fields":[{"name":"deprecationReason","description":null,"args":[],"type":{"kind":"SCALAR","name":"String","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"description","description":null,"args":[],"type":{"kind":"SCALAR","name":"String","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"isDeprecated","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"Boolean","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"name","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"isDeprecated":false,"deprecationReason":null}],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"OBJECT","name":"Query","description":null,"fields":[],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"OBJECT","name":"Mutation","description":null,"fields":[{"name":"createRsvp","description":null,"args":[{"name":"input","description":null,"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"INPUT_OBJECT","name":"createRsvpInput","ofType":null}},"defaultValue":null}],"type":{"kind":"OBJECT","name":"Rsvp","ofType":null},"isDeprecated":false,"deprecationReason":null}],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"OBJECT","name":"Rsvp","description":null,"fields":[{"name":"email","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"event_id","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"guests","description":null,"args":[{"name":"first","description":"Returns
+        the first _n_ elements from the list.","type":{"kind":"SCALAR","name":"Int","ofType":null},"defaultValue":null},{"name":"after","description":"Returns
+        the elements in the list that come after the specified global ID.","type":{"kind":"SCALAR","name":"String","ofType":null},"defaultValue":null},{"name":"last","description":"Returns
+        the last _n_ elements from the list.","type":{"kind":"SCALAR","name":"Int","ofType":null},"defaultValue":null},{"name":"before","description":"Returns
+        the elements in the list that come before the specified global ID.","type":{"kind":"SCALAR","name":"String","ofType":null},"defaultValue":null}],"type":{"kind":"OBJECT","name":"GuestConnection","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"id","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"ID","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"name","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"total_count","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"Int","ofType":null}},"isDeprecated":false,"deprecationReason":null}],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"SCALAR","name":"ID","description":"Represents
+        a unique identifier that is Base64 obfuscated. It is often used to refetch
+        an object or as key for a cache. The ID type appears in a JSON response as
+        a String; however, it is not intended to be human-readable. When expected
+        as an input type, any string (such as `\"VXNlci0xMA==\"`) or integer (such
+        as `4`) input value will be accepted as an ID.","fields":null,"inputFields":null,"interfaces":null,"enumValues":null,"possibleTypes":null},{"kind":"SCALAR","name":"Int","description":"Represents
+        non-fractional signed whole numeric values. Int can represent values between
+        -(2^31) and 2^31 - 1.","fields":null,"inputFields":null,"interfaces":null,"enumValues":null,"possibleTypes":null},{"kind":"OBJECT","name":"GuestConnection","description":"The
+        connection type for Guest.","fields":[{"name":"edges","description":"A list
+        of edges.","args":[],"type":{"kind":"LIST","name":null,"ofType":{"kind":"OBJECT","name":"GuestEdge","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"pageInfo","description":"Information
+        to aid in pagination.","args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"PageInfo","ofType":null}},"isDeprecated":false,"deprecationReason":null}],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"OBJECT","name":"GuestEdge","description":"An
+        edge in a connection.","fields":[{"name":"cursor","description":"A cursor
+        for use in pagination.","args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"node","description":"The
+        item at the end of the edge.","args":[],"type":{"kind":"OBJECT","name":"Guest","ofType":null},"isDeprecated":false,"deprecationReason":null}],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"OBJECT","name":"Guest","description":null,"fields":[{"name":"email","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"id","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"ID","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"name","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"isDeprecated":false,"deprecationReason":null}],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"OBJECT","name":"PageInfo","description":"Information
+        about pagination in a connection.","fields":[{"name":"endCursor","description":"When
+        paginating forwards, the cursor to continue.","args":[],"type":{"kind":"SCALAR","name":"String","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"hasNextPage","description":"When
+        paginating forwards, are there more items?","args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"Boolean","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"hasPreviousPage","description":"When
+        paginating backwards, are there more items?","args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"Boolean","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"startCursor","description":"When
+        paginating backwards, the cursor to continue.","args":[],"type":{"kind":"SCALAR","name":"String","ofType":null},"isDeprecated":false,"deprecationReason":null}],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"INPUT_OBJECT","name":"createRsvpInput","description":"Autogenerated
+        input type of createRsvp","fields":null,"inputFields":[{"name":"clientMutationId","description":"A
+        unique identifier for the client performing the mutation.","type":{"kind":"SCALAR","name":"String","ofType":null},"defaultValue":null},{"name":"name","description":null,"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"defaultValue":null},{"name":"email","description":null,"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"defaultValue":null},{"name":"event_id","description":null,"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"defaultValue":null},{"name":"guests","description":null,"type":{"kind":"LIST","name":null,"ofType":{"kind":"NON_NULL","name":null,"ofType":{"kind":"INPUT_OBJECT","name":"RsvpGuest","ofType":null}}},"defaultValue":null}],"interfaces":null,"enumValues":null,"possibleTypes":null},{"kind":"INPUT_OBJECT","name":"RsvpGuest","description":null,"fields":null,"inputFields":[{"name":"name","description":null,"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"defaultValue":null},{"name":"email","description":null,"type":{"kind":"SCALAR","name":"String","ofType":null},"defaultValue":null}],"interfaces":null,"enumValues":null,"possibleTypes":null},{"kind":"OBJECT","name":"__Schema","description":"A
+        GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
+        available types and directives on the server, as well as the entry points
+        for query, mutation, and subscription operations.","fields":[{"name":"directives","description":"A
+        list of all directives supported by this server.","args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"LIST","name":null,"ofType":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"__Directive","ofType":null}}}},"isDeprecated":false,"deprecationReason":null},{"name":"mutationType","description":"If
+        this server supports mutation, the type that mutation operations will be rooted
+        at.","args":[],"type":{"kind":"OBJECT","name":"__Type","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"queryType","description":"The
+        type that query operations will be rooted at.","args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"__Type","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"subscriptionType","description":"If
+        this server support subscription, the type that subscription operations will
+        be rooted at.","args":[],"type":{"kind":"OBJECT","name":"__Type","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"types","description":"A
+        list of all types supported by this server.","args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"LIST","name":null,"ofType":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"__Type","ofType":null}}}},"isDeprecated":false,"deprecationReason":null}],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"OBJECT","name":"__Directive","description":"A
+        Directive provides a way to describe alternate runtime execution and type
+        validation behavior in a GraphQL document.\n\nIn some cases, you need to provide
+        options to alter GraphQL''s execution behavior in ways field arguments will
+        not suffice, such as conditionally including or skipping a field. Directives
+        provide this by describing additional information to the executor.","fields":[{"name":"args","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"LIST","name":null,"ofType":{"kind":"NON_NULL","name":null,"ofType":{"kind":"OBJECT","name":"__InputValue","ofType":null}}}},"isDeprecated":false,"deprecationReason":null},{"name":"description","description":null,"args":[],"type":{"kind":"SCALAR","name":"String","ofType":null},"isDeprecated":false,"deprecationReason":null},{"name":"locations","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"LIST","name":null,"ofType":{"kind":"NON_NULL","name":null,"ofType":{"kind":"ENUM","name":"__DirectiveLocation","ofType":null}}}},"isDeprecated":false,"deprecationReason":null},{"name":"name","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String","ofType":null}},"isDeprecated":false,"deprecationReason":null},{"name":"onField","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"Boolean","ofType":null}},"isDeprecated":true,"deprecationReason":"Use
+        `locations`."},{"name":"onFragment","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"Boolean","ofType":null}},"isDeprecated":true,"deprecationReason":"Use
+        `locations`."},{"name":"onOperation","description":null,"args":[],"type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"Boolean","ofType":null}},"isDeprecated":true,"deprecationReason":"Use
+        `locations`."}],"inputFields":null,"interfaces":[],"enumValues":null,"possibleTypes":null},{"kind":"ENUM","name":"__DirectiveLocation","description":"A
+        Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation
+        describes one such possible adjacencies.","fields":null,"inputFields":null,"interfaces":null,"enumValues":[{"name":"QUERY","description":"Location
+        adjacent to a query operation.","isDeprecated":false,"deprecationReason":null},{"name":"MUTATION","description":"Location
+        adjacent to a mutation operation.","isDeprecated":false,"deprecationReason":null},{"name":"SUBSCRIPTION","description":"Location
+        adjacent to a subscription operation.","isDeprecated":false,"deprecationReason":null},{"name":"FIELD","description":"Location
+        adjacent to a field.","isDeprecated":false,"deprecationReason":null},{"name":"FRAGMENT_DEFINITION","description":"Location
+        adjacent to a fragment definition.","isDeprecated":false,"deprecationReason":null},{"name":"FRAGMENT_SPREAD","description":"Location
+        adjacent to a fragment spread.","isDeprecated":false,"deprecationReason":null},{"name":"INLINE_FRAGMENT","description":"Location
+        adjacent to an inline fragment.","isDeprecated":false,"deprecationReason":null},{"name":"SCHEMA","description":"Location
+        adjacent to a schema definition.","isDeprecated":false,"deprecationReason":null},{"name":"SCALAR","description":"Location
+        adjacent to a scalar definition.","isDeprecated":false,"deprecationReason":null},{"name":"OBJECT","description":"Location
+        adjacent to an object type definition.","isDeprecated":false,"deprecationReason":null},{"name":"FIELD_DEFINITION","description":"Location
+        adjacent to a field definition.","isDeprecated":false,"deprecationReason":null},{"name":"ARGUMENT_DEFINITION","description":"Location
+        adjacent to an argument definition.","isDeprecated":false,"deprecationReason":null},{"name":"INTERFACE","description":"Location
+        adjacent to an interface definition.","isDeprecated":false,"deprecationReason":null},{"name":"UNION","description":"Location
+        adjacent to a union definition.","isDeprecated":false,"deprecationReason":null},{"name":"ENUM","description":"Location
+        adjacent to an enum definition.","isDeprecated":false,"deprecationReason":null},{"name":"ENUM_VALUE","description":"Location
+        adjacent to an enum value definition.","isDeprecated":false,"deprecationReason":null},{"name":"INPUT_OBJECT","description":"Location
+        adjacent to an input object type definition.","isDeprecated":false,"deprecationReason":null},{"name":"INPUT_FIELD_DEFINITION","description":"Location
+        adjacent to an input object field definition.","isDeprecated":false,"deprecationReason":null}],"possibleTypes":null}],"directives":[{"name":"include","description":"Directs
+        the executor to include this field or fragment only when the `if` argument
+        is true.","locations":["FIELD","FRAGMENT_SPREAD","INLINE_FRAGMENT"],"args":[{"name":"if","description":"Included
+        when true.","type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"Boolean","ofType":null}},"defaultValue":null}]},{"name":"skip","description":"Directs
+        the executor to skip this field or fragment when the `if` argument is true.","locations":["FIELD","FRAGMENT_SPREAD","INLINE_FRAGMENT"],"args":[{"name":"if","description":"Skipped
+        when true.","type":{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"Boolean","ofType":null}},"defaultValue":null}]},{"name":"deprecated","description":"Marks
+        an element of a GraphQL schema as no longer supported.","locations":["FIELD_DEFINITION","ENUM_VALUE"],"args":[{"name":"reason","description":"Explains
+        why this element was deprecated, usually also including a suggestion for how
+        to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).","type":{"kind":"SCALAR","name":"String","ofType":null},"defaultValue":"\"No
+        longer supported\""}]}]}}}'
+    http_version:
+  recorded_at: Wed, 18 Oct 2017 21:03:00 GMT
+- request:
+    method: post
+    uri: https://constellation-staging.artsy.net/api/graphql/
+    body:
+      encoding: UTF-8
       string: '{"query":"mutation Constellation__CreateRsvpMutation($input: createRsvpInput!)
         {\n  createRsvp(input: $input) {\n    id\n    total_count\n  }\n}","variables":{"input":{"name":"Matt","email":"matt@email.com","event_id":""}},"operationName":"Constellation__CreateRsvpMutation"}'
     headers:
@@ -49,6 +210,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"data":{"createRsvp":null},"errors":[{"message":"Validation failed:
         Event can''t be blank","locations":[{"line":2,"column":3}],"path":["createRsvp"]}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 18 Oct 2017 21:04:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/lib/constellation_spec.rb
+++ b/spec/lib/constellation_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Constellation module' do
-  
+
   context 'requests' do
     let(:rsvp_params) { { name: 'Matt', email: 'matt@email.com', event_id: "420" }.with_indifferent_access }
     it 'makes the right POST request with headers and body, and returns the total count' do
@@ -16,16 +16,8 @@ describe 'Constellation module' do
         expect do
           Constellation.create_rsvp!(rsvp_params)
         end.to raise_error(Constellation::GraphQLException) do |e|
-          expect(e.message).to eq 'Validation failed: Event can\'t be blank'
+          expect(e.message).to eq "Validation failed: Event can't be blank"
         end
-      end
-    end
-    it 'raises an exception on a more generic http error' do
-      allow(Net::HTTP).to receive(:new).and_raise(SocketError.new('uh oh'))
-      expect do
-        Constellation.create_rsvp!(rsvp_params)
-      end.to raise_error(Constellation::HttpException) do |e|
-        expect(e.message).to eq 'uh oh'
       end
     end
   end


### PR DESCRIPTION
A bit cleaner. Removed all the special HTTP handling, we never want to see our RSVP app crash, so bubble up any `StandardError`.

Closes https://github.com/artsy/rsvp/issues/52.

With https://github.com/ashkan18/graphlient/pull/27 we can also remove the error check in `constellation.rb`.