### PR TITLE
Let Graphlient raise an execution error.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
       activerecord (>= 4.0.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
-    graphlient (0.0.7)
+    graphlient (0.1.0)
       faraday
       faraday_middleware
       graphql-client
@@ -218,7 +218,7 @@ GEM
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
-    tzinfo (1.2.3)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uglifier (3.0.3)
       execjs (>= 0.3.0, < 3)

--- a/lib/constellation.rb
+++ b/lib/constellation.rb
@@ -1,7 +1,4 @@
 module Constellation
-
-  class GraphQLException < StandardError; end;
-
   def self.client
     Graphlient::Client.new(
       "#{RsvpRails.config[:constellation_url]}/api/graphql/",
@@ -24,12 +21,6 @@ module Constellation
     variables[:input][:event_id] = variables[:input][:event_id].to_s
 
     response = client.execute(mutation, variables)
-
-    if response.data.errors.any?
-      error_messages = response.data.errors.messages.to_h
-      message = error_messages.map { |_, e| e.join(', ') }.join(', ')
-      raise Constellation::GraphQLException, message
-    end
 
     return response.data, response.data.create_rsvp.total_count
   end

--- a/spec/lib/constellation_spec.rb
+++ b/spec/lib/constellation_spec.rb
@@ -15,8 +15,8 @@ describe 'Constellation module' do
       VCR.use_cassette('unsuccessful Constellation creation') do
         expect do
           Constellation.create_rsvp!(rsvp_params)
-        end.to raise_error(Constellation::GraphQLException) do |e|
-          expect(e.message).to eq "Validation failed: Event can't be blank"
+        end.to raise_error Graphlient::Errors::ExecutionError do |e|
+          expect(e.message).to eq "createRsvp: Validation failed: Event can't be blank"
         end
       end
     end


### PR DESCRIPTION
Graphlient 0.1.0 will raise an exception in [all kinds of cases](https://github.com/ashkan18/graphlient#error-handling). This is actually quite a bit more involved than what we were doing here, see https://github.com/github/graphql-client/pull/132.